### PR TITLE
Fix positioning of position: fixed elements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "type": "phpbb-extension",
     "description": "Enable switching between Dark and Light mode",
     "homepage": "https://www.team-azerty.com",
-    "version": "1.0.2",
+    "version": "1.0.3",
     "time": "2020-09-01",
 		"keywords": ["phpbb", "extension", "style", "Dark Mode"],
     "license": "GPL-2.0-only",

--- a/event/listener.php
+++ b/event/listener.php
@@ -52,11 +52,11 @@ class listener implements EventSubscriberInterface
 			'core.adm_page_header'		=> 'do_dark',
 		);
 	}
-	
+
 	public function do_dark($event)
 	{
 		$cookie_darkmode_name = $this->config['cookie_name'] . '_darkmode';
-		
+
 		$dark_case = $this->request->variable($cookie_darkmode_name, false, false, \phpbb\request\request_interface::COOKIE);
 		if ($dark_case)
 		{
@@ -70,11 +70,11 @@ class listener implements EventSubscriberInterface
 			$style_do_dark = "";
 			$class = "lightmode";
 		}
-    
+
 		$this->user->add_lang_ext('aurelienazerty/darkmode', 'dark_mode');
-		
+
 		$this->template->assign_vars(array(
-			'BODY_CLASS'							=> 	$class,
+			'S_DARKMODE_ROOT_CLASS'				=> 	$class,
 			'STYLE_DO_DARK'						=> 	$style_do_dark,
 			'STYLE_DO_LIGHT'					=> 	$style_do_light,
 			'DO_DARK_MESSAGE'					=> 	$this->user->lang['DO_DARK_MODE'],

--- a/styles/all/template/darkmode_body.html
+++ b/styles/all/template/darkmode_body.html
@@ -1,4 +1,6 @@
 {% INCLUDECSS '@aurelienazerty_darkmode/darkmode.css' %}
 <script>
 	var cookie_darkmode_name = '{{ S_COOKIE_DARKMODE_NAME | escape('js') }}';
+
+	document.documentElement.classList.add('{{ S_DARKMODE_ROOT_CLASS }}')
 </script>

--- a/styles/all/theme/darkmode.css
+++ b/styles/all/theme/darkmode.css
@@ -1,22 +1,16 @@
-body.darkmode {
-  filter: invert(1) hue-rotate(.5turn);
-  padding: 15px;
-}
-
-.darkmode img, .darkmode iframe, .darkmode video, .darkmode .adsbygoogle {
+:root.darkmode {
   filter: invert(1) hue-rotate(.5turn);
 }
 
-.darkmode img:not(:hover) {
+:root.darkmode :is(img, iframe, video, .adsbygoogle) {
+  filter: invert(1) hue-rotate(.5turn);
+}
+
+:root.darkmode img:not(:hover) {
   opacity: .7;
   transition: opacity .25s ease-in-out;
 }
 
-.darkmode .headerbar {
+:root.darkmode .headerbar {
 	background-image: none;
-}
-
-/** Fix for Quick Reply Releaded extension */
-.darkmode .qr_fixed_form {
-	position: sticky;
 }

--- a/styles/all/theme/darkmode.js
+++ b/styles/all/theme/darkmode.js
@@ -1,13 +1,15 @@
 function darkmode(doDark) {
 	if (doDark) {
-		$("body").addClass("darkmode");
+		$("html").addClass("darkmode");
+		$("html").removeClass("lightmode");
 		$("#callDark").hide();
 		$("#callLight").show();
 		var date = new Date();
-		date.setTime(date.getTime()+(365*24*60*60*1000));
+		date.setTime(date.getTime() + (365 * 24 * 60 * 60 * 1000));
 		document.cookie = cookie_darkmode_name + "=true;expires=" + date.toGMTString() + ";path=/";
 	} else {
-		$("body").removeClass("darkmode");
+		$("html").addClass("lightmode");
+		$("html").removeClass("darkmode");
 		$("#callDark").show();
 		$("#callLight").hide();
 		var date = new Date();

--- a/styles/prosilver_se/theme/darkmode.css
+++ b/styles/prosilver_se/theme/darkmode.css
@@ -1,17 +1,4 @@
-body.darkmode {
-  filter: invert(1) hue-rotate(.5turn);
-}
-
-.darkmode img, .darkmode iframe, .darkmode video, .darkmode .adsbygoogle {
-  filter: invert(1) hue-rotate(.5turn);
-}
-
-.darkmode img:not(:hover) {
-  opacity: .7;
-  transition: opacity .25s ease-in-out;
-}
-
-/** Les couleurs sont inversées 
+/** Les couleurs sont inversées
 		http://www.mattlag.com/scripting/hexcolorinverter.php
 */
 .darkmode .headerbar {
@@ -21,9 +8,4 @@ body.darkmode {
 
 .darkmode .headerbar h1, .darkmode .headerbar p {
 	color: #000000;
-}
-
-/** Fix for Quick Reply Releaded extension */
-.darkmode .qr_fixed_form {
-	position: sticky;
 }


### PR DESCRIPTION
Darkmode breaks the positioning of all `position: fixed` elements on the page (modals, loading spinners, etc). This becomes apparent when you trigger a modal from low down a page that is taller than the screen hight, such as subscribing to a forum; the loading spinner and modal are "invisible" due to being placed above the visible viewport.

Demo (the modal should be fixed in place, not scrolling with the background):

![darkmode-pos-fixed-bug](https://user-images.githubusercontent.com/26078826/161430259-aa11271b-edc9-4fca-8a91-b469c8928ac8.gif)

The bug is due to this:

https://stackoverflow.com/questions/52937708/why-does-applying-a-css-filter-on-the-parent-break-the-child-positioning

>A value other than none for the filter property results in the creation of a containing block for absolute and fixed positioned descendants **unless the element it applies to is a document root element in the current browsing context**. The list of functions are applied in the order provided.

To fix this, we apply apply the `darkmode` class and `filter: invert(1) hue-rotate(.5turn)` style to the `:root` element (i.e. `html`), not `body`.